### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 AI-ユーザー間の復唱確認プロトコルを実装するMCPサーバーです。LLMが不安になったときに、ユーザーに確認を取るためのツールを提供します。
 
-# @mako10k/mcp-confirm
+<a href="https://glama.ai/mcp/servers/@mako10k/mcp-confirm">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mako10k/mcp-confirm/badge" alt="MCP-Confirm MCP server" />
+</a>
 
 A Model Context Protocol (MCP) server for AI-user confirmation and clarification. This server provides tools for AI assistants (LLMs) to ask users for confirmation when they need clarification or verification.
 


### PR DESCRIPTION
This PR adds a badge for the [MCP-Confirm](https://glama.ai/mcp/servers/@mako10k/mcp-confirm) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mako10k/mcp-confirm">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mako10k/mcp-confirm/badge" alt="MCP-Confirm MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.