### PR TITLE
タイムアウトデフォルト値を3分に変更 & GitHub Codespaces開発環境設定追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,67 @@
+{
+  "name": "MCP Confirm Development",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+  
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": ".devcontainer/post-create.sh",
+
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "typescript.preferences.includePackageJsonAutoImports": "auto",
+        "typescript.suggest.autoImports": true,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true,
+          "**/.git": true
+        }
+      },
+      
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-next",
+        "bradlc.vscode-tailwindcss",
+        "ms-vscode.vscode-json",
+        "redhat.vscode-yaml",
+        "ms-vscode.vscode-eslint",
+        "formulahendry.auto-rename-tag",
+        "christian-kohler.path-intellisense",
+        "streetsidesoftware.code-spell-checker",
+        "ms-vscode.vscode-markdown",
+        "bierner.markdown-mermaid",
+        "davidanson.vscode-markdownlint"
+      ]
+    }
+  },
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+
+  // Use 'mounts' to make the source code available in the container.
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/workspaces/mcp-confirm,type=bind"
+  ],
+
+  // Environment variables
+  "containerEnv": {
+    "NODE_ENV": "development"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,6 @@
       "extensions": [
         "esbenp.prettier-vscode",
         "ms-vscode.vscode-typescript-next",
-        "bradlc.vscode-tailwindcss",
         "ms-vscode.vscode-json",
         "redhat.vscode-yaml",
         "ms-vscode.vscode-eslint",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Welcome message
+echo "🚀 Setting up MCP Confirm development environment..."
+
+# Install dependencies
+echo "📦 Installing npm dependencies..."
+npm install
+
+# Build the project
+echo "🔨 Building the project..."
+npm run build
+
+# Create necessary directories
+echo "📁 Creating necessary directories..."
+mkdir -p .mcp-data
+
+echo "✅ Setup complete! You can now:"
+echo "  - Run 'npm run dev' to start development"
+echo "  - Run 'npm run build' to build the project"
+echo "  - Run 'npm start' to run the built project"
+echo "  - Run 'npm run lint' to check code quality"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 # Old files
 README_old.md
 test-server.js
+
+# Codespaces
+.devcontainer/.env

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -27,7 +27,7 @@
 			],
 			"env": {
 				"MCP_CONFIRM_LOG_PATH": "${workspaceFolder}/.mcp-data/confirmation_history.log",
-				"MCP_CONFIRM_TIMEOUT_MS": "60000",
+				"MCP_CONFIRM_TIMEOUT_MS": "180000",
 				"NODE_ENV": "production"
 			}
 		}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,117 @@
+# Development Setup
+
+このプロジェクトはGitHub Codespacesでの開発に最適化されています。
+
+## Quick Start
+
+1. GitHub Codespacesでこのリポジトリを開く
+2. 自動的にセットアップが実行されます
+3. セットアップ完了後、以下のコマンドが使用可能です：
+
+## Available Commands
+
+```bash
+# 開発モード（TypeScriptコンパイル + 実行）
+npm run dev
+
+# プロジェクトをビルド
+npm run build
+
+# ビルド済みプロジェクトを実行
+npm start
+
+# コード品質チェック
+npm run lint
+npm run format:check
+
+# コード自動修正
+npm run lint:fix
+npm run format
+
+# 全品質チェック
+npm run quality
+```
+
+## Development Environment
+
+### Container Configuration
+
+- **Base Image**: `mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye`
+- **Node.js**: v20
+- **包含機能**: Git, GitHub CLI
+
+### VS Code Extensions
+
+自動的にインストールされる拡張機能：
+- Prettier - コードフォーマッター
+- ESLint - リンター
+- TypeScript拡張
+- Markdown拡張
+- Path IntelliSense
+- Auto Rename Tag
+
+### Environment Variables
+
+開発環境では以下の環境変数が設定されます：
+- `NODE_ENV=development`
+
+## Project Structure
+
+```
+.
+├── .devcontainer/          # Dev Container設定
+│   ├── devcontainer.json  # メイン設定
+│   └── post-create.sh     # セットアップスクリプト
+├── .vscode/               # VS Code設定
+│   ├── settings.json      # エディタ設定
+│   ├── tasks.json        # タスク定義
+│   ├── launch.json       # デバッグ設定
+│   └── mcp.json          # MCP設定
+├── src/                  # ソースコード
+├── dist/                 # ビルド出力
+└── .mcp-data/           # ログデータ
+```
+
+## Debugging
+
+デバッグ設定が含まれています：
+1. F5キーまたは「Run and Debug」パネルから「Debug MCP Elicitation Server」を選択
+2. ブレークポイントを設定して実行
+
+## Testing the MCP Server
+
+ローカルでMCPサーバーをテストする場合：
+
+```bash
+# サーバーを起動
+npm start
+
+# または開発モード
+npm run dev
+```
+
+## Troubleshooting
+
+### セットアップが失敗した場合
+
+```bash
+# 手動でセットアップスクリプトを実行
+./.devcontainer/post-create.sh
+```
+
+### 依存関係の問題
+
+```bash
+# node_modulesを削除して再インストール
+rm -rf node_modules package-lock.json
+npm install
+```
+
+### ビルドエラー
+
+```bash
+# TypeScriptキャッシュをクリア
+rm -rf dist/
+npx tsc --build --clean
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ npm install -g @mako10k/mcp-confirm
 npx @mako10k/mcp-confirm
 ```
 
+## Development with GitHub Codespaces
+
+このプロジェクトはGitHub Codespacesでの開発をサポートしています：
+
+1. GitHubでこのリポジトリを開く
+2. 「Code」ボタンをクリック
+3. 「Codespaces」タブを選択
+4. 「Create codespace on main」をクリック
+5. 自動的に開発環境がセットアップされます
+
+詳細は[DEVELOPMENT.md](DEVELOPMENT.md)を参照してください。
+
 ## Configuration
 
 ### Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
-  "name": "mcp-confirm",
-  "version": "1.0.0",
+  "name": "@mako10k/mcp-confirm",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mcp-confirm",
-      "version": "1.0.0",
+      "name": "@mako10k/mcp-confirm",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "bin": {
+        "mcp-confirm": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -20,6 +23,9 @@
         "jscpd": "^4.0.5",
         "prettier": "^3.6.2",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format:check": "prettier --check src/**/*.ts",
     "jscpd": "jscpd ./src",
     "quality": "npm run lint && npm run format:check && npm run jscpd",
-    "prepublishOnly": "npm run build && npm run quality"
+    "prepublishOnly": "npm run build && npm run quality",
+    "codespaces:setup": ".devcontainer/post-create.sh"
   },
   "keywords": [
     "mcp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ class ConfirmationMCPServer {
   private loadConfig(): ServerConfig {
     const defaultConfig: ServerConfig = {
       confirmationHistoryPath: ".mcp-data/confirmation_history.log",
-      defaultTimeoutMs: 60000, // 60 seconds
+      defaultTimeoutMs: 180000, // 3 minutes
     };
 
     // TODO: Load from config file if exists


### PR DESCRIPTION
## 変更内容

### タイムアウト設定の改善
- デフォルトタイムアウト値を 60秒から180秒（3分） に変更
- ユーザーからの「60秒は短い」というフィードバックに対応

### GitHub Codespaces開発環境の追加
- 完全な開発環境をブラウザ上で利用可能
- 自動セットアップスクリプトで即座に開発開始可能

## 追加された機能

### Dev Container設定
- ベースイメージ: TypeScript/Node.js 20
- 自動インストール: Git, GitHub CLI
- VS Code拡張機能: Prettier, ESLint, TypeScript等の自動インストール
- 環境変数: 開発環境用の設定

### 自動セットアップスクリプト
- 依存関係の自動インストール
- プロジェクトの自動ビルド
- 必要なディレクトリの作成

### 開発者向けドキュメント
- DEVELOPMENT.md: 開発環境のセットアップ手順
- README.md: Codespaces使用方法を追記

## メリット

1. アクセシビリティ向上: どこからでもブラウザ上で開発可能
2. セットアップ時間の短縮: 数分で完全な開発環境が利用可能
3. 環境の統一: 全開発者が同じ環境で作業
4. 新規参加者の障壁低減: 複雑なローカル環境構築が不要